### PR TITLE
Fixed script double reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
     <script defer src='js/jquery/jquery-3.2.0.min.js'></script>
     <script defer src='js/jquery/jquery-migrate-3.0.0.min.js'></script>
     <script defer src='js/jquery/jquery-ui.min.js'></script>
-    <script defer src="js/materialize.js"></script>
+    <!--<script defer src="js/materialize.js"></script>-->
     <script defer src="js/init.js"></script>
     <script defer src="min/plugin-min.js"></script>
     <script defer src="min/custom-min.js"></script>


### PR DESCRIPTION
Materialize was included both as a standalone script and as minimized script, which was causing rendering problems. Fixed by commenting out one of two.